### PR TITLE
chore: bump ci-workflows to v5

### DIFF
--- a/.github/workflows/build-on-branch.yml
+++ b/.github/workflows/build-on-branch.yml
@@ -9,9 +9,9 @@ permissions:
 
 jobs:
   check:
-    uses: zenhelix/ci-workflows/.github/workflows/kotlin-library-check.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/kotlin-library-check.yml@v5
     with:
       java-version: '21'
 
   label:
-    uses: zenhelix/ci-workflows/.github/workflows/labeler.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/labeler.yml@v5

--- a/.github/workflows/build-on-main.yml
+++ b/.github/workflows/build-on-main.yml
@@ -9,13 +9,13 @@ permissions:
 
 jobs:
   check:
-    uses: zenhelix/ci-workflows/.github/workflows/kotlin-library-check.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/kotlin-library-check.yml@v5
     with:
       java-version: '21'
 
   create-tag:
     needs: check
-    uses: zenhelix/ci-workflows/.github/workflows/gradle-create-tag.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/gradle-create-tag.yml@v5
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   analyze:
-    uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/codeql-analysis.yml@v5

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    uses: zenhelix/ci-workflows/.github/workflows/kotlin-library-release.yml@v4
+    uses: zenhelix/ci-workflows/.github/workflows/kotlin-library-release.yml@v5
     with:
       java-version: '21'
       publish-command: './gradlew publish -Pversion=''${{ github.ref_name }}'''


### PR DESCRIPTION
## Summary
Bulk bump per Spec 13 Phase 1.5 (after pilot validated on maven-central-publish#37).

`@v4` → `@v5` in all `.github/workflows/*.yml`.

## Why
v5 of `zenhelix/ci-workflows` fixes:
- Bug #1b: `check.yml` was missing `actions/checkout` → exit 127 across all 9 Kotlin/Java consumers
- Bug #1: `conventional-commit-check.yml` was failing 0s on push → now skips correctly
- Bug #2: `codeql-analysis.yml` got `configuration_error` because explicit `compileKotlin` ran outside CodeQL tracing → now uses `build-mode: autobuild`
- Concurrency cascade: reusable workflows used `${{ github.workflow }}` which collided when called from same parent workflow → now hardcoded per-workflow

## Test plan
- [ ] After merge: `Build & Tag` and `CodeQL` on main turn green (vs cancelled/failure on v4)
- [ ] `create-tag` job actually runs (was being skipped due to concurrency cascade)